### PR TITLE
Use gdm3 instead of gdm (LP: #1582439)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Vcs-Browser: http://github.com/tseliot/nvidia-prime
 
 Package: nvidia-prime
 Architecture: i386 amd64
-Depends: lightdm (>= 1.9.1) | gdm | kdm | sddm, bbswitch-dkms,
+Depends: lightdm (>= 1.9.1) | gdm3 | kdm | sddm, bbswitch-dkms,
  pciutils, lsb-release, ${shlibs:Depends}, ${misc:Depends}
 Conflicts: hybrid-graphics
 Replaces: hybrid-graphics


### PR DESCRIPTION
https://launchpad.net/bugs/1582439

Please SRU to Ubuntu 16.04 LTS since this bug is bad for Ubuntu GNOME.

Installing a second display manager triggers a debconf prompt asking the user to pick between two display managers, but users aren't given any information about what the consequences of that choice are. (lightdm doesn't integrate as well with GNOME Shell). http://askubuntu.com/q/789314/1579