### PR TITLE
Remove obsolete udev rules during `postrm upgrade` too

### DIFF
--- a/debian/postrm.in
+++ b/debian/postrm.in
@@ -23,9 +23,10 @@ case "$1" in
         if [ ! "$1" = "upgrade" ]; then
             # Remove the settings
             rm -f /etc/prime-discrete
-            rm -f /lib/udev/rules.d/50-pm-nvidia.rules
-            rm -f /lib/udev/rules.d/80-pm-nvidia.rules
         fi
+        # Remove obsolete udev rules
+        rm -f /lib/udev/rules.d/50-pm-nvidia.rules
+        rm -f /lib/udev/rules.d/80-pm-nvidia.rules
     ;;
 
     *)


### PR DESCRIPTION
This commit aims to fix the problem in nvidia-prime 0.8.15 where
/lib/udev/rules.d/50-pm-nvidia.rules was left behind after a system
upgrade 20.04 LTS (focal) to 20.10 (groovy), and yet prime-select
had lost the ability to remove the udev rules file,
leaving the end user with no means to re-enable his/her Nvidia GPU.

----

By the way, thank you so much @khfeng and @tseliot for getting rid of 50-pm-nvidia.rules and 80-pm-nvidia.rules for groovy (20.10).  Finally, end users like the ones at https://askubuntu.com/questions/1251350/gpu-disappeard-from-hardware-device-list (and me) no longer need to panic and pull their hair out when the Nvidia GPU disappears from `lspci` altogether and not knowing how to get it back, and often may not be able to find the solution despite hours or googling because the answer is so obscure...