### PR TITLE
Set on-demand mode as default nvidia mode (LP: #1942307)

### DIFF
--- a/debian/preinst.in
+++ b/debian/preinst.in
@@ -25,7 +25,8 @@ case "$1" in
         fi
 
         if [ ! -f /etc/prime-discrete ]; then
-            echo "on" > /etc/prime-discrete
+            # Supported if the version of nvidia driver is greater than 450
+            echo "on-demand" > /etc/prime-discrete
         fi
     ;;
 


### PR DESCRIPTION
[Steps to reproduce]
1. Install 20.04.3 with "Third-party packages" on a system which containing a RTD3 supported nvidia card.
2. After the installation, press enter to reboot system
3. prime-select query

[Expected result]
on-demand

[Actual result]
performance

---

It's because ubiquity launches `ubuntu-drivers install --packages-list ...` in live system but install each package to target storage.

When installing nvidia-prime, the preinst set "on" to "/etc/prime-discrete" which will be referred by gpu-manager. The gpu-manager will set to performance mode.

After confirming with Alberto on Mattermost, since we don't have a nvidia driver which lower than 450 version since focal.

I think we are ok to switch to on-demand mode.